### PR TITLE
Basic GetNews functionality added

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ var spellService = require('./spell-service');
 // Setup Restify Server
 var server = restify.createServer();
 server.listen(process.env.port || process.env.PORT || 3978, function () {
+  console.log('%s listening to %s', server.name, server.url);
 });
 // Create connector and listen for messages
 var connector = new builder.ChatConnector({

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 // This loads the environment variables from the .env file
 require('dotenv-extended').load();
 var railway = require('./railwayHelper');
+var news = require('./newsHelper');
 
 var builder = require('botbuilder');
 var restify = require('restify');
@@ -33,3 +34,8 @@ bot.dialog('PNRStatus', function (session, args) {
 	matches: 'PNRStatus'
 });
 
+bot.dialog('TopNews', function (session, args) {
+  news.newsHelper(session, args);
+}).triggerAction({
+	matches: 'TopNews'
+});

--- a/newsHelper.js
+++ b/newsHelper.js
@@ -1,0 +1,63 @@
+var request = require('request');
+var util = require('./util');
+var builder = require('botbuilder');
+
+var newsHelper = function(session, args) {
+  if(args.intent.score > 0.99){
+          getNews(session, function(topNews){
+              //messageUser(session,ttechcrunchopNews.articles[0].title);
+              var newsCards = getallnewscards(session, topNews);
+              // create reply with Carousel AttachmentLayout
+              var reply = new builder.Message(session)
+                  .attachmentLayout(builder.AttachmentLayout.carousel)
+                  .attachments(newsCards);
+
+              session.send(reply);
+          });
+
+  }else{
+    util.messageUser(session,"Type \'help\' if you need assistance.");
+  }
+}
+
+function getNews(session, cb) {
+	var news_api_key = '365758ccf07b492384e1ff1b50316168';
+  //Presently fetching only top news from "Tech Crunch"
+  //Have to do it for around 70 news sources which would serve news to users with queries like
+  // Fetch me the top/latest news from times of india/bbc news/cnbc etc.
+	var url = ' https://newsapi.org/v1/articles?source=techcrunch&sortBy=top&apiKey=' + news_api_key;
+	console.log(url);
+	request(url, function(error, response, body) {
+		if(error) {
+			util.messageUser(session, 'Some network error');
+		}
+		if(response.statusCode !== 200) {
+			util.messageUser(session, 'Retry');
+		}
+		var topnews = JSON.parse(body);
+		if(topnews.status !== "ok") {
+			util.messageUser(session, "Try Again!!");
+		}
+		else {
+			cb(topnews);
+		}
+	});
+}
+
+function getallnewscards(session, TopNews){
+  var newscards = [];
+  for(i=0; i!=TopNews.articles.length; i++){
+      newscards[i] = new builder.HeroCard(session)
+            .title(TopNews.articles[i].title)
+            .text(TopNews.articles[i].description)
+            .images([
+                builder.CardImage.create(session, TopNews.articles[i].urlToImage)
+            ])
+            .buttons([
+                builder.CardAction.openUrl(session, TopNews.articles[i].url, 'Read Complete')
+            ]);
+  }
+  return newscards;
+}
+
+module.exports.newsHelper = newsHelper;


### PR DESCRIPTION
You can review this by adding intent and utterances as follows:
![intent](https://cloud.githubusercontent.com/assets/8044561/24266192/f77b3a9c-102b-11e7-8576-8aaee4fae5af.png)
![utterances](https://cloud.githubusercontent.com/assets/8044561/24266197/fd418814-102b-11e7-8bf9-5bf41e2fb7bd.png)
Right now, there is no entity being used because it is fetching top news only from Techcrunch. I would be extending it further for fetching news from around 70 news sources which would cater user requests like
`Fetch me the latest news from Times of India`
News should be displayed as:
![getnews_test](https://cloud.githubusercontent.com/assets/8044561/24266459/cdba73c0-102c-11e7-9b64-c0509251e0d6.png)
